### PR TITLE
🔧 Use dash in ingress config

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: Deploy application to ${{ needs.build.outputs.environment }}
         env:
           ENVIRONMENT: ${{ needs.build.outputs.environment }}
-          STAGING_PREFIX: ${{ needs.build.outputs.environment == 'staging' && 'staging.' || '' }}
+          STAGING_PREFIX: ${{ needs.build.outputs.environment == 'staging' && 'staging-' || '' }}
           REPO_NAME: ${{ needs.build.outputs.repo-name }}
           COMMIT_SHA: ${{ needs.build.outputs.commit-sha }}
           DOCKERHUB_USERNAME: ${{ secrets.ORG_DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Use dash in ingress config to allow for the use of mTLS to hide our staging apps from the general public. CloudFlare's proxy server by default only protects us on the root domain and one level down, which would not be possible with a link like
`staging.api.masterofcubesau.com`. To workaround this, we will use `staging-` instead.